### PR TITLE
Correct sample pressure generation

### DIFF
--- a/TDDMicroExercises/PHP/TirePressureMonitoringSystem/Sensor.php
+++ b/TDDMicroExercises/PHP/TirePressureMonitoringSystem/Sensor.php
@@ -9,7 +9,7 @@ class Sensor
 	public static function SamplePressure()
 	{
 		// placeholder implementation that simulate a real sensor in a real tire
-		$pressureTelemetryValue = floor(6 * rand() * rand());
+		$pressureTelemetryValue = floor(6 * self::randomFloat(0, 1) * self::randomFloat(0, 1));
 		return $pressureTelemetryValue;
 	}
 
@@ -17,5 +17,10 @@ class Sensor
 	{
 		$pressureTelemetryValue = self::SamplePressure();
 		return self::OFFSET + $pressureTelemetryValue;
+	}
+	
+	private static function randomFloat($min = 0, $max = 1)
+	{
+		return $min + mt_rand() / mt_getrandmax() * ($max - $min);
 	}
 }


### PR DESCRIPTION
The `SamplePressure` method return incorrect value. `rand()` method in PHP generate integer between 0 and `getrandmax()` (which return the biggest value and not `1`) (see https://www.php.net/manual/fr/function.rand.php)
There is no "simple" way (one call to a php native method) to generate float number between 0 and 1.
